### PR TITLE
added unloadable editor to prevent hard crashing

### DIFF
--- a/Stride.Editor.Design/SceneEditor/UnloadableEditor.cs
+++ b/Stride.Editor.Design/SceneEditor/UnloadableEditor.cs
@@ -1,0 +1,22 @@
+﻿using Stride.Assets.Entities;
+using Stride.Core;
+using Stride.Core.Assets;
+using Stride.Engine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stride.Editor.Design.SceneEditor;
+public class UnloadableEditor : IAssetEditor
+{
+	public Asset Asset { get; }
+
+	public string AssetName { get; set; } = "";
+
+	public UnloadableEditor(Asset asset, IServiceRegistry services)
+	{
+		Asset = asset;
+	}
+}

--- a/Stride.Editor.Design/SceneEditor/UnloadableViewModel.cs
+++ b/Stride.Editor.Design/SceneEditor/UnloadableViewModel.cs
@@ -1,0 +1,26 @@
+﻿using Stride.Assets.Entities;
+using Stride.Editor.Design.Core.Hierarchy;
+using Stride.Engine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stride.Editor.Design.SceneEditor;
+public class UnloadableViewModel
+{
+
+
+	public EntityHierarchyAssetBase AssetSource { get; }
+
+	public Scene GameSource { get; }
+
+	public IAssetEditor Editor { get; }
+
+	public UnloadableViewModel(EntityHierarchyAssetBase asset, IAssetEditor editor)
+	{
+		AssetSource = asset;
+		Editor = editor;
+	}
+}

--- a/Stride.Editor.Presentation.VirtualDom/Stride.Editor.Presentation.VirtualDom.csproj
+++ b/Stride.Editor.Presentation.VirtualDom/Stride.Editor.Presentation.VirtualDom.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Dock.Avalonia" Version="0.10.0" />
     <PackageReference Include="Dock.Model.Avalonia" Version="0.10.0" />
     <PackageReference Include="Dock.Avalonia.Themes.Default" Version="0.10.0" />
-    <PackageReference Include="FSharp.Core" Version="6.0.5" />
+    <PackageReference Include="FSharp.Core" Version="7.0.300-beta.23114.3" />
     <PackageReference Include="Stride.Core.Design" Version="4.1.0.1731" />
     <PackageReference Include="Stride.Core.Yaml" Version="4.1.0.1731" />
 

--- a/Stride.Editor.Presentation/SceneEditor/UnloadableEditorView.cs
+++ b/Stride.Editor.Presentation/SceneEditor/UnloadableEditorView.cs
@@ -1,0 +1,21 @@
+﻿using Stride.Core;
+using Stride.Editor.Design.SceneEditor;
+using Virtual = Stride.Editor.Presentation.VirtualDom.Controls;
+
+namespace Stride.Editor.Presentation.SceneEditor;
+public class UnloadableEditorView : ViewBase<Design.SceneEditor.UnloadableEditor>
+{
+	public UnloadableEditorView(IServiceRegistry services) : base(services)
+	{
+	}
+
+	public override IViewBuilder CreateView(UnloadableEditor viewModel)
+	{
+		
+
+		return new Virtual.TextBlock
+		{
+			Text = "There is no registered Editor for this type"
+		};
+	}
+}

--- a/Stride.Editor/Plugins/SceneEditorPlugin.cs
+++ b/Stride.Editor/Plugins/SceneEditorPlugin.cs
@@ -1,5 +1,6 @@
 ﻿using Stride.Assets.Entities;
 using Stride.Core;
+using Stride.Core.Assets;
 using Stride.Editor.Design;
 using Stride.Editor.Design.SceneEditor;
 using Stride.Editor.Presentation;
@@ -12,11 +13,13 @@ namespace Stride.Editor.Plugins
         public void RegisterPlugin(IServiceRegistry services)
         {
             var viewRegistry = services.GetSafeServiceAs<ViewRegistry>();
+            viewRegistry.RegisterView<UnloadableEditor, UnloadableEditorView>();
             viewRegistry.RegisterView<SceneEditor, SceneEditorView>();
 
             var assetManager = services.GetSafeServiceAs<IAssetEditorRegistry>();
-            assetManager.RegisterAssetEditor<SceneAsset, SceneEditor>();
-        }
+            assetManager.RegisterAssetEditor<Asset, UnloadableEditor>();
+			assetManager.RegisterAssetEditor<SceneAsset, SceneEditor>();
+		}
 
         public void UnregisterPlugin(IServiceRegistry services)
         {


### PR DESCRIPTION
I was getting annoyed at opening unsupported assets causing a crash. This should fix that while still telling the user it is unloadable.